### PR TITLE
Adds filter to link attributes

### DIFF
--- a/wp_bem_menu.php
+++ b/wp_bem_menu.php
@@ -128,6 +128,8 @@ class walker_texas_ranger extends Walker_Nav_Menu {
 		$attributes .= ! empty( $item->xfn ) ? ' rel="' . esc_attr( $item->xfn ) . '"' : '';
 		$attributes .= ! empty( $item->url ) ? ' href="' . esc_attr( $item->url ) . '"' : '';
 
+		$attributes = apply_filters( 'bem_menu_link_attributes', $attributes, $item );
+
 		// Create link markup
 		if ( is_object( $args ) ) {
 			$item_output  = $args->before;


### PR DESCRIPTION
Add a new filter `bem_menu_link_attributes` to modify the link attributes of a menu item. For example to add a `hreflang` and `lang` attribute